### PR TITLE
URI-encode filename and sessionID in downloadFileUrl

### DIFF
--- a/src/model/api.js
+++ b/src/model/api.js
@@ -39,9 +39,9 @@ function downloadFileURL(fileName) {
   return (
     API.defaults.baseURL +
     '/api/download/file?file=' +
-    fileName +
+    encodeURIComponent(fileName) +
     '&client_id=' +
-    sessionID
+    encodeURIComponent(sessionID)
   )
 }
 


### PR DESCRIPTION
Hi!

This PR fixes spotDL/spotify-downloader#1604 . The filename for the download was not encoded, which led to issues with files having special characters.

I didn't add the built `dist`, as I figured you would not want that.